### PR TITLE
Support for Windows 10 1903

### DIFF
--- a/lib/ps/windows_firewall/ps-bridge.ps1
+++ b/lib/ps/windows_firewall/ps-bridge.ps1
@@ -50,9 +50,9 @@ function Get-PSFirewallRules {
             # Address Filter
             LocalAddress = $af.LocalAddress.toString()
             RemoteAddress = $af.RemoteAddress.toString()
-            # Port Filter
-            LocalPort = $pf.LocalPort
-            RemotePort = $pf.RemotePort
+            # Port Filter (Newer powershell versions return a hash)
+            LocalPort = if ($pf.RemotePort -is [object]) { $pf.RemotePort["value"] -join "," } else { $pf.RemotePort }
+            RemotePort =if ($pf.LocalPort -is [object]) { $pf.LocalPort["value"]  -join "," } else { $pf.LocalPort }
             Protocol = $pf.Protocol
             IcmpType = $pf.IcmpType
             # Application Filter


### PR DESCRIPTION
Powershell on latest Windows 10 build has changed and port filter objects now
return hashes instead of strings which was breaking the bridge script.

If hashes are detected munge them to strings (1903), otherwise just return the
value as-is.