### PR TITLE
move from require to require_relative

### DIFF
--- a/lib/puppet/provider/windows_firewall_global/ruby.rb
+++ b/lib/puppet/provider/windows_firewall_global/ruby.rb
@@ -1,5 +1,5 @@
 require 'puppet_x'
-require 'puppet_x/windows_firewall'
+require_relative '../../../puppet_x/windows_firewall'
 
 Puppet::Type.type(:windows_firewall_global).provide(:windows_firewall_global, :parent => Puppet::Provider) do
   confine :osfamily => :windows

--- a/lib/puppet/provider/windows_firewall_group/ruby.rb
+++ b/lib/puppet/provider/windows_firewall_group/ruby.rb
@@ -1,5 +1,5 @@
 require 'puppet_x'
-require 'puppet_x/windows_firewall'
+require_relative '../../../puppet_x/windows_firewall'
 
 Puppet::Type.type(:windows_firewall_group).provide(:windows_firewall_group, :parent => Puppet::Provider) do
   confine :osfamily => :windows

--- a/lib/puppet/provider/windows_firewall_profile/ruby.rb
+++ b/lib/puppet/provider/windows_firewall_profile/ruby.rb
@@ -1,5 +1,5 @@
 require 'puppet_x'
-require 'puppet_x/windows_firewall'
+require_relative '../../../puppet_x/windows_firewall'
 
 Puppet::Type.type(:windows_firewall_profile).provide(:windows_firewall_profile, :parent => Puppet::Provider) do
   confine :osfamily => :windows

--- a/lib/puppet/provider/windows_firewall_rule/ruby.rb
+++ b/lib/puppet/provider/windows_firewall_rule/ruby.rb
@@ -1,5 +1,5 @@
 require 'puppet_x'
-require 'puppet_x/windows_firewall'
+require_relative '../../../puppet_x/windows_firewall'
 
 Puppet::Type.type(:windows_firewall_rule).provide(:windows_firewall_rule, :parent => Puppet::Provider) do
   confine :osfamily => :windows


### PR DESCRIPTION
In multi environment setup, the module will require windows_firewall, which will fail because the module's directory is not in the ruby LOAD_PATH. The module needs to use require_relative instead