### PR TITLE
sort required due to netsh output

### DIFF
--- a/examples/wfr_new_rule.pp
+++ b/examples/wfr_new_rule.pp
@@ -139,6 +139,6 @@ windows_firewall_rule { "puppet - multiple remote and local addresses":
   profile        => ["private", "domain"],
   local_port     => 7777,
   remote_port    => 7777,
-  local_address  => "192.168.1.1,10.10.10.10",
-  remote_address => "192.168.1.2,192.168.2.11",
+  local_address  => sort("192.168.1.1,10.10.10.10"),
+  remote_address => sort("192.168.1.2,192.168.2.11"),
 }

--- a/lib/ps/windows_firewall/ps-bridge.ps1
+++ b/lib/ps/windows_firewall/ps-bridge.ps1
@@ -127,7 +127,9 @@ function Get-NormalizedIpAddressRange {
 		}
 		$ipAddress += @(if ($fixedIpAddress) { $fixedIpAddress } else { $addr })
 	}
-	
+    # Sort IPs address (netsh output doesn't sort them) 
+    $ipAddress = $ipAddress | Sort-Object
+
     return $ipAddress -join ","
 }
 


### PR DESCRIPTION
We have discovered that netsh output doesn't sort local_address or remote_address (With show/get-netfirewallrule, it's not the case)
To avoid corrective loop, this change is providing a sorted result